### PR TITLE
[ENH] Get BOTS list directly from intelmqctl

### DIFF
--- a/intelmq_api/api.py
+++ b/intelmq_api/api.py
@@ -136,6 +136,11 @@ def queues_and_status():
     return runner.list("queues-and-status")
 
 
+@cache_get("/api/bots", requires=token_authentication, versions=1)
+def bots():
+    return runner.list("bots")
+
+
 @hug.get("/api/version", requires=token_authentication, versions=1)
 def version(request):
     return runner.version()

--- a/intelmq_api/files.py
+++ b/intelmq_api/files.py
@@ -59,7 +59,6 @@ class FileAccess:
             } # type: Dict[str, Path]
 
         self.readonly_files = {
-            'bots': Path('/opt/intelmq/etc/BOTS'),
             'harmonization': Path('/opt/intelmq/etc/harmonization.conf'),
             } # type: Dict[str, Path]
 
@@ -69,7 +68,6 @@ class FileAccess:
         self.writable_files["runtime"] = Path(paths["RUNTIME_CONF_FILE"])
         self.writable_files["positions"] = Path(paths["CONFIG_DIR"]
                                                 + "/manager/positions.conf")
-        self.readonly_files["bots"] = Path(paths["BOTS_FILE"])
         self.readonly_files["harmonization"] = Path(paths["HARMONIZATION_CONF_FILE"])
 
     def file_name_allowed(self, filename: str) -> Optional[Tuple[bool, Path]]:


### PR DESCRIPTION
The BOTS file got removed, so we get the list out of
intelmqctl itself. On demand generated

**NOTE** Wait for https://github.com/certtools/intelmq/pull/1751 merge.