### PR TITLE
monitor, bot logs: fix log level filter ALL

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,5 @@
 ..
-   SPDX-FileCopyrightText: 2020-2023 Birger Schacht, Sebastian Wagner
+   SPDX-FileCopyrightText: 2020-2023 nic.at GmbH, 2025 Institute for Common Good Technology, Sebastian Wagner
    SPDX-License-Identifier: AGPL-3.0-or-later
 
 CHANGELOG
@@ -8,10 +8,16 @@ CHANGELOG
 3.3.1 (unreleased)
 ----------------------
 
+## Monitor
+^^^^^^^^^^
+
+- Bot logs: fix log level filter "ALL" (PR#49 by Sebastian Wagner, fixes #48).
+
 Tests
 ^^^^^
 
 - Update Python versions: remove 3.7, add 3.12, 3.13 (PR#50 by Sebastian Wagner).
+
 
 3.3.0 (2024-03-01)
 ----------------------

--- a/intelmq_api/runctl.py
+++ b/intelmq_api/runctl.py
@@ -113,7 +113,7 @@ class RunIntelMQCtl:
 
     def log(self, bot_id: str, lines: int, level: str) -> JSONFile:
         if level == "ALL":
-            level = "DEBUG"
+            return self._run_json(["log", bot_id, str(lines)])
         return self._run_json(["log", bot_id, str(lines), level])
 
     def list(self, kind: str) -> JSONFile:


### PR DESCRIPTION
in level filter ALL, only DEBUG messages were shown. instead, show all log levels as intended

fixes https://github.com/certtools/intelmq-api/issues/48